### PR TITLE
https://bugzilla.org/ → https://www.bugzilla.org/

### DIFF
--- a/src/chrome/content/rules/Bugzilla.xml
+++ b/src/chrome/content/rules/Bugzilla.xml
@@ -1,10 +1,9 @@
 <!--
 	For other Mozilla coverage, see Mozilla.xml.
 
-
-	Nonfunctional subdomains:
-
-		- planet
+	Nonfunctional hostnames:
+		- bugzilla.org (certificate for lists.bugzilla.org only)
+		- planet.bugzilla.org
 
 -->
 <ruleset name="Bugzilla">
@@ -12,7 +11,7 @@
 	<target host="bugzilla.org" />
 	<target host="*.bugzilla.org" />
 
-	<rule from="^http://bugzilla\.org/"
+	<rule from="^https?://bugzilla\.org/"
 		to="https://www.bugzilla.org/" />
 	<rule from="^http://(www|landfill|lists)\.bugzilla\.org/"
 		to="https://$1.bugzilla.org/" />


### PR DESCRIPTION
Prevent certificate warning at bugzilla.org